### PR TITLE
fix: remove the line using PathRequest.toH2Console() in SecurityConfig

### DIFF
--- a/gildongmu-api/src/main/java/codeit/api/config/SecurityConfig.java
+++ b/gildongmu-api/src/main/java/codeit/api/config/SecurityConfig.java
@@ -36,8 +36,7 @@ public class SecurityConfig {
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
             .authorizeHttpRequests(
                 authorize -> authorize
-                    .requestMatchers(PathRequest.toH2Console()).permitAll()
-                    .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                    .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**").permitAll()
                     .anyRequest().hasRole("USER")
             )
             .exceptionHandling(config ->


### PR DESCRIPTION
## 🔎 PR Description
- Close #10 
> fix the error that No qualifying bean of type 'org.springframework.boot.autoconfigure.h2.H2ConsoleProperties' available

## 🔑 Key Changes
- remove the line using PathRequest.toH2Console() in SecurityConfig

## 📢 To Reviewers
- This PR is the simple change, so I will merge into develop without review