### PR TITLE
refactor: use implementation instead of unnecessary inheritance

### DIFF
--- a/gildongmu-common/src/main/java/codeit/common/security/OAuth2LoginSuccessHandler.java
+++ b/gildongmu-common/src/main/java/codeit/common/security/OAuth2LoginSuccessHandler.java
@@ -1,7 +1,6 @@
 package codeit.common.security;
 
 import codeit.domain.user.constant.Role;
-import codeit.domain.user.entity.User;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,12 +20,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
         OAuth2LoginUser oAuth2LoginUser = (OAuth2LoginUser) authentication.getPrincipal();
-        User loginUser = oAuth2LoginUser.getUser();
 
-        if (Role.ROLE_GUEST.equals(loginUser.getRole())) {
+        if (oAuth2LoginUser.hasAuthority(Role.ROLE_GUEST)) {
             response.sendRedirect("/oauth2/signup");
-        } else if (Role.ROLE_USER.equals(loginUser.getRole())) {
-            response.sendRedirect("/oauth2/token");
+        } else if (oAuth2LoginUser.hasAuthority(Role.ROLE_GUEST)) {
+            response.sendRedirect("/oauth2/login");
         }
 
     }

--- a/gildongmu-common/src/main/java/codeit/common/security/OAuth2LoginUser.java
+++ b/gildongmu-common/src/main/java/codeit/common/security/OAuth2LoginUser.java
@@ -1,20 +1,47 @@
 package codeit.common.security;
 
+import codeit.domain.user.constant.Role;
 import codeit.domain.user.entity.User;
 import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
-import java.util.Collections;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
-@Getter
-public class OAuth2LoginUser extends DefaultOAuth2User {
+public class OAuth2LoginUser implements OAuth2User {
+    @Getter
     private final User user;
+    private final List<GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
 
     public OAuth2LoginUser(OAuth2User oAuth2User, String nameAttributeKey, User user) {
-        super(Collections.singleton(new SimpleGrantedAuthority(user.getRole().name())),
-                oAuth2User.getAttributes(), nameAttributeKey);
+        authorities = List.of(new SimpleGrantedAuthority(user.getRole().name()));
+        attributes = oAuth2User.getAttributes();
+        this.nameAttributeKey = nameAttributeKey;
         this.user = user;
+    }
+
+    public boolean hasAuthority(Role role){
+        return authorities.stream()
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(role.name()));
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return nameAttributeKey;
     }
 }


### PR DESCRIPTION
## 🔎 PR Description
> When inheriting `DefaultOAuth2User`, the structure becomes complex, leading to decreased code readability. Therefore, I opted to implement `OAuth2User` for a simpler structure.

## 🔑 Key Changes
-  use implementation instead of inheritance

## 📢 To Reviewers
