### PR TITLE
feat: handle participant accepted event

### DIFF
--- a/gildongmu-domain/src/main/java/codeit/domain/post/entity/Post.java
+++ b/gildongmu-domain/src/main/java/codeit/domain/post/entity/Post.java
@@ -1,6 +1,6 @@
 package codeit.domain.post.entity;
 
-import codeit.domain.bookmark.entity.Bookmark;
+import codeit.domain.Bookmark.entity.Bookmark;
 import codeit.domain.Image.entity.Image;
 import codeit.domain.comment.entity.Comment;
 import codeit.domain.common.BaseTimeEntity;

--- a/gildongmu-domain/src/main/java/codeit/domain/post/repository/PostRepository.java
+++ b/gildongmu-domain/src/main/java/codeit/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package codeit.domain.post.repository;
 
+import codeit.domain.post.constant.Status;
 import codeit.domain.post.entity.Post;
 import codeit.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
@@ -21,4 +22,5 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
     @Query("select p from Post p left join Participant u on p.id = u.post.id where u.user.id = ?1 and u.status != 'DELETED' and u.isLeader = false order by p.status desc")
     Slice<Post> findByParticipantUserOrderByStatusDesc(Long userId, Pageable pageable);
 
+    Optional<Post> findByIdAndStatus(Long postId, Status status);
 }

--- a/gildongmu-domain/src/main/java/codeit/domain/room/entity/Room.java
+++ b/gildongmu-domain/src/main/java/codeit/domain/room/entity/Room.java
@@ -1,6 +1,7 @@
 package codeit.domain.room.entity;
 
 import codeit.domain.common.BaseTimeEntity;
+import codeit.domain.post.entity.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,13 +21,24 @@ public class Room extends BaseTimeEntity {
 
     private LocalDateTime lastChatAt;
 
-    private Integer headcount;
+    private int headcount;
 
-    // TODO: add post
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
 
     @Builder
-    public Room(LocalDateTime lastChatAt, Integer headcount) {
+    public Room(LocalDateTime lastChatAt, Integer headcount, Post post) {
         this.lastChatAt = lastChatAt;
         this.headcount = headcount;
+        this.post = post;
+    }
+
+    public void plusHeadCount() {
+        headcount++;
+    }
+
+    public void minusHeadCount() {
+        headcount--;
     }
 }

--- a/gildongmu-domain/src/main/java/codeit/domain/room/repository/RoomRepository.java
+++ b/gildongmu-domain/src/main/java/codeit/domain/room/repository/RoomRepository.java
@@ -1,9 +1,14 @@
 package codeit.domain.room.repository;
 
+import codeit.domain.post.entity.Post;
 import codeit.domain.room.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    Optional<Room> findByPost(Post post);
+    Optional<Room> findByPostId(Long postId);
 }


### PR DESCRIPTION
## 🔎 PR Description
- Close #55 
> add handling process about the participant accepted or denied

## 🔑 Key Changes
- if post participants equals rooms headcount, post status is changed to close
- update rooms head count when accepted participant is denied or created or exit


## 📢 To Reviewers
